### PR TITLE
Fix feedback page at end of game

### DIFF
--- a/ClimateConversationsCore.py
+++ b/ClimateConversationsCore.py
@@ -198,7 +198,7 @@ class Conversation(object):
             raise ValueError("No game in progress found")
         players = [Player(p[0], p[1]) for p in player_tuples]
         questions = session.get('convo_questions')
-        if not questions:
+        if questions is None:
             raise ValueError("No game in progress found")
 
         return cls(event_store, players, questions)
@@ -246,7 +246,7 @@ class Conversation(object):
         return cls(event_store, players, questions)
 
     def game_is_active(self):
-        return self.questions != []
+        return bool(self.questions)
 
     def get_next_question(self):
         if not self.questions:


### PR DESCRIPTION
This was a subtle bug in loading the game state from session cookies,
once the game is complete the questions array is empty which was
evaluated to false in load_from_session() and raied the No game in
progress error.